### PR TITLE
Fix discovery when advertisement doesn't contain a useful name

### DIFF
--- a/examples/cli_usage.py
+++ b/examples/cli_usage.py
@@ -19,13 +19,13 @@ def data_table(data: dict, serial: int) -> Table:
 
 
 if __name__ == "__main__":
-    device = WaveDevice.create("Airthings Wave+", "80:6F:B0:A0:E0:00", 2930000000)
+    device = WaveDevice.create("Airthings Wave+", "80:6F:B0:A0:E0:00", '2930000000')
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(device.get_sensor_values())
 
     console = Console()
-    console.print(data_table(device.sensors.as_dict(), device.serial_number))
+    console.print(data_table(device.sensors.as_dict(), device.serial))
 
 # Prints the following output:
 #

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,6 +1,3 @@
-from wave_reader.data import WaveProduct
-
-
 class MockedBLEDevice:
     def __init__(self):
         self.name = "Airthings Wave+"
@@ -13,10 +10,10 @@ class MockedBLEDevice:
                 "b42e1c08-ade7-11e4-89d3-123b93f75cba"
                 "f000ffc0-0451-4000-b000-000000000000"
             ],
-            "manufacturer_data": {820: [13, 25, 160, 170, 9, 0]},
+            # Represents '2930618893', a valid serial for a model 2930 (Wave+)
+            "manufacturer_data": {820: [13, 178, 173, 174, 9, 0]},
         }
         self.address = "80:XO:XO:XO:EE:48"
-        self.product: WaveProduct = WaveProduct(self.name)
 
 
 class MockedBleakClient(object):

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -158,12 +158,12 @@ class TestDeviceSensors(TestCase):
             "dew_point: 3.56)",
         )
 
-    def test_wave(self):
-        """Test WAVE device is returning the correct sensor values."""
+    def test_wave2(self):
+        """Test WAVE2 device is returning the correct sensor values."""
 
         device_sensors = wave.DeviceSensors.from_bytes(
             (1, 125, 0, 0, 140, 145, 2000),
-            data.WaveProduct.WAVE,
+            data.WaveProduct.WAVE2,
         )
         expected_dict = {
             "humidity": 62.5,

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -68,6 +68,16 @@ class TestWave(IsolatedAsyncioTestCase):
         self.assertFalse(devices)
         self.assertTrue(mocked_logger.called)
 
+    @patch("wave_reader.wave.discover")
+    async def test_discover_valid_unnamed_device(self, mocked_discover):
+        """Test device discovery when the BLE advertisement does not include the model name."""
+        BLEUnnamedDevice = deepcopy(self.BLEDevice)
+        BLEUnnamedDevice.name = BLEUnnamedDevice.address.replace(':', '-')
+
+        mocked_discover.return_value = [BLEUnnamedDevice]
+        devices = await wave.discover_devices()
+        self.assertNotEqual(devices, [])
+
     def test_wave_device__str__(self):
         """Test the __str__ method is matching our expected value."""
 

--- a/wave_reader/data.py
+++ b/wave_reader/data.py
@@ -17,7 +17,7 @@ MANUFACTURER_DATA_FORMAT = "<LH"
 
 DEVICE = {
     WaveProduct.WAVEPLUS: {
-        "name": "Wave+",
+        "NAME": "Wave+",
         "UUID": "b42e2a68-ade7-11e4-89d3-123b93f75cba",
         "BUFFER": "<BBBBHHHHHHHH",
         "SENSOR_FORMAT": (
@@ -33,20 +33,15 @@ DEVICE = {
         ),
     },
     WaveProduct.WAVE: {
-        "name": "Wave",
+        "NAME": "Wave",
         "UUID": "b42e4dcc-ade7-11e4-89d3-123b93f75cba",
-        "BUFFER": "<4B8H",
+        "BUFFER": "<H5B4H",
         "SENSOR_FORMAT": (
-            lambda d: {
-                "humidity": d[1] / 2.0 if d[1] else 0,
-                "radon_sta": d[4],
-                "radon_lta": d[5],
-                "temperature": d[6] / 100.0 if d[6] else 0,
-            }
+            lambda d: {}
         ),
     },
     WaveProduct.WAVE2: {
-        "name": "Wave (2nd Gen)",
+        "NAME": "Wave (2nd Gen)",
         "UUID": "b42e4dcc-ade7-11e4-89d3-123b93f75cba",
         "BUFFER": "<4B8H",
         "SENSOR_FORMAT": (
@@ -59,7 +54,7 @@ DEVICE = {
         ),
     },
     WaveProduct.WAVEMINI: {
-        "name": "Wave Mini",
+        "NAME": "Wave Mini",
         "UUID": "b42e3b98-ade7-11e4-89d3-123b93f75cba",
         "BUFFER": "<HHHHHHLL",
         "SENSOR_FORMAT": (

--- a/wave_reader/data.py
+++ b/wave_reader/data.py
@@ -2,15 +2,22 @@ from enum import Enum
 
 
 class WaveProduct(Enum):
-    WAVEPLUS = "Airthings Wave+"
-    WAVE = "Airthings Wave"
-    WAVEMINI = "Airthings Wave Mini"
+    WAVE = '2900'
+    WAVEMINI = '2920'
+    WAVEPLUS = '2930'
+    WAVE2 = '2950'
 
 
-IDENTITY = 820
-SERIAL_NUMBER_BUFFER = "<LH"
+# Company Identifier registered with the Bluetooth SIG
+# Officially registered as "Corentium AS"
+AIRTHINGS_ID = 820
+
+# Model and serial number
+MANUFACTURER_DATA_FORMAT = "<LH"
+
 DEVICE = {
     WaveProduct.WAVEPLUS: {
+        "name": "Wave+",
         "UUID": "b42e2a68-ade7-11e4-89d3-123b93f75cba",
         "BUFFER": "<BBBBHHHHHHHH",
         "SENSOR_FORMAT": (
@@ -26,6 +33,20 @@ DEVICE = {
         ),
     },
     WaveProduct.WAVE: {
+        "name": "Wave",
+        "UUID": "b42e4dcc-ade7-11e4-89d3-123b93f75cba",
+        "BUFFER": "<4B8H",
+        "SENSOR_FORMAT": (
+            lambda d: {
+                "humidity": d[1] / 2.0 if d[1] else 0,
+                "radon_sta": d[4],
+                "radon_lta": d[5],
+                "temperature": d[6] / 100.0 if d[6] else 0,
+            }
+        ),
+    },
+    WaveProduct.WAVE2: {
+        "name": "Wave (2nd Gen)",
         "UUID": "b42e4dcc-ade7-11e4-89d3-123b93f75cba",
         "BUFFER": "<4B8H",
         "SENSOR_FORMAT": (
@@ -38,6 +59,7 @@ DEVICE = {
         ),
     },
     WaveProduct.WAVEMINI: {
+        "name": "Wave Mini",
         "UUID": "b42e3b98-ade7-11e4-89d3-123b93f75cba",
         "BUFFER": "<HHHHHHLL",
         "SENSOR_FORMAT": (

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -10,7 +10,7 @@ from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
 from bleak.backends.device import BLEDevice
 
 from wave_reader.data import (
-    DEVICE, IDENTITY, SERIAL_NUMBER_BUFFER, WaveProduct,
+    AIRTHINGS_ID, DEVICE, MANUFACTURER_DATA_FORMAT, WaveProduct,
 )
 
 _logger = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class WaveDevice:
     properties: ``name``, ``address`` and optionally ``rssi``, ``metadata``.
 
     :param device: Device information from Bleak's discover function
-    :param serial_number: Parsed serial number from manufacturer data
+    :param serial: Parsed serial number from manufacturer data
     """
 
     sensor_version: Optional[int] = None
@@ -104,24 +104,28 @@ class WaveDevice:
     _client: Optional[BleakClientBlueZDBus] = None
     _raw_gatt_values: Optional[bytearray] = None
 
-    def __init__(self, device: Union[BLEDevice, Any], serial_number: int):
+    def __init__(self, device: Union[BLEDevice, Any], serial: str):
         self.name: str = device.name
         self.address: str = device.address  # UUID in MacOS, or MAC in Linux and Windows
         self.rssi: Optional[int] = getattr(device, "rssi", None)
         self.metadata: Optional[Dict[str, Union[List, Dict]]] = getattr(
             device, "metadata", None
         )
-        self.product: WaveProduct = WaveProduct(self.name)
-        self.serial_number: int = serial_number
+        self.serial: str = serial
+        self.model = self.serial[:4]
+        try:
+            self.product: WaveProduct = WaveProduct(self.model)
+        except KeyError:
+            raise ValueError
 
     def __eq__(self, other):
-        for prop in ("name", "address", "serial_number"):
+        for prop in ("name", "address", "serial"):
             if getattr(self, prop) != getattr(other, prop):
                 return False
         return True
 
     def __str__(self):
-        return f"WaveDevice ({self.serial_number})"
+        return f"WaveDevice ({self.serial})"
 
     def _map_sensor_values(self):
         try:
@@ -149,7 +153,7 @@ class WaveDevice:
                 return self._map_sensor_values()
 
     @staticmethod
-    def parse_serial_number(manufacturer_data: Dict[int, int]) -> Optional[int]:
+    def parse_manufacturer_data(manufacturer_data: Dict[int, int]) -> Optional[str]:
         """Converts manufacturer data and returns a serial number for the
         Airthings Wave devices.
 
@@ -160,23 +164,23 @@ class WaveDevice:
 
         identity, data = list(manufacturer_data.items())[0]
         try:
-            (serial_number, _) = struct.unpack(SERIAL_NUMBER_BUFFER, bytes(data))
+            (serial, _) = struct.unpack(MANUFACTURER_DATA_FORMAT, bytes(data))
         except (struct.error, TypeError):
             return None
         else:
-            return serial_number if identity == IDENTITY else None
+            return str(serial) if identity == AIRTHINGS_ID else None
 
     @classmethod
-    def create(cls, name: str, address: str, serial_number: int):
+    def create(cls, name: str, address: str, serial: str):
         """Create a WaveDevice instance with three distinct arguments.
 
         :param name: The device product name. See ``wave_reader.data.WaveProduct``
             for a full list of supported devices.
         :param address: The device UUID in MacOS, or MAC in Linux and Windows.
-        :param serial_number: The serial number for the device.
+        :param serial: The serial number for the device.
         """
         device = namedtuple("device", ["name", "address"])
-        return cls(device(name, address), serial_number)
+        return cls(device(name, address), serial)
 
 
 async def discover_devices() -> List[WaveDevice]:
@@ -184,16 +188,20 @@ async def discover_devices() -> List[WaveDevice]:
     wave_devices = []
     device: BLEDevice  # Typing annotation
     for device in await discover():
-        serial_number = WaveDevice.parse_serial_number(
+        serial = WaveDevice.parse_manufacturer_data(
             device.metadata.get("manufacturer_data")
         )
-        if not serial_number:
+        if not serial:
             _logger.debug(
                 f"Device: {device.name} ({device.address}) was not identified as a Wave device."
             )
             continue
         try:
-            wave_devices.append(WaveDevice(device, serial_number))
+            wave_device = WaveDevice(device, serial)
+            wave_devices.append(wave_device)
+            _logger.debug(
+                f"Device: {device.name} ({device.address}) identified as a Wave device model {wave_device.model}."
+            )
         except ValueError:
             _logger.warning(
                 f"Device: {device.name} ({device.address}) was identified, but unsupported."

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -113,10 +113,7 @@ class WaveDevice:
         )
         self.serial: str = serial
         self.model = self.serial[:4]
-        try:
-            self.product: WaveProduct = WaveProduct(self.model)
-        except KeyError:
-            raise ValueError
+        self.product: WaveProduct = WaveProduct(self.model)
 
     def __eq__(self, other):
         for prop in ("name", "address", "serial"):


### PR DESCRIPTION
Hi @ztroop! Thanks for creating a community version of the Airthings code.

When I gave your code a try with my 2nd generation Wave, sadly it didn't recognize the device. As far as I can tell, the problem is due to how you are relying on the BLE advertisement name to determine the model. 

With my device and on my system (Linux using BlueZ 5.55), the BLE name shows up as a fairly anonymous-looking variant on the MAC address (e.g. "12-34-56-78-90-AB"). Every once in a while, it would be populated with the real name "Airthings Wave2", but only reliably if I connected to the device first (such as via bluetoothctl).

Here's my attempt at a fix that reworks WaveProduct to be indexed by model number (instead of name), and modified detection code based on the decoded serial number. As far as I can tell from various photos online, the serial number always embeds the model as the first 4 digits.

I also added a test for the original issue, as well as a new data section for the 2nd generation Wave product.