### PR TITLE
0.0.5 Release Candidate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ test:
 	tox
 
 clean:
-	rm -rf *.egg-info build dist .tox .coverage .pytest_cache coverage.xml .mypy_cache
+	rm -rf *.egg-info build dist .tox .coverage .pytest_cache coverage.xml .mypy_cache site

--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ These are the goals for this project, _in no particular order_:
 - [x] Support operation across multiple devices asynchronously.
 - [x] Code testing, linting, type hinting, formatting and coverage reporting.
 - [x] Discover all Wave devices or inherit WaveDevice class for sensor readings.
+- [x] Support other devices like Wave (Version 1).
 - [ ] Add battery life support.
-- [ ] Implement reconnection logic for BTLE client.
-- [ ] Support other devices like Wave (Version 1) and more.
 
 ## Requirements
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     author='Zackary Troop',
     name='wave-reader',
-    version='0.0.4',
+    version='0.0.5',
     url='https://github.com/ztroop/wave-reader-utils',
     license='MIT',
     description='Unofficial package for Airthings Wave communication.',

--- a/wave_reader/data.py
+++ b/wave_reader/data.py
@@ -19,7 +19,7 @@ SENSOR_VER_SUPPORTED = 1
 DEVICE = {
     WaveProduct.WAVEPLUS: {
         "NAME": "Wave+",
-        "UUID": "b42e2a68-ade7-11e4-89d3-123b93f75cba",
+        "UUID": ("b42e2a68-ade7-11e4-89d3-123b93f75cba",),
         "BUFFER": "<BBBBHHHHHHHH",
         "SENSOR_FORMAT": (
             lambda d: {
@@ -35,13 +35,25 @@ DEVICE = {
     },
     WaveProduct.WAVE: {
         "NAME": "Wave",
-        "UUID": "b42e4dcc-ade7-11e4-89d3-123b93f75cba",
+        "UUID": (
+            "00000000-0000-0000-0000-000000002a6f",  # Humidity
+            "00000000-0000-0000-0000-000000002a6e",  # Temperature
+            "b42e01aa-ade7-11e4-89d3-123b93f75cba",  # Radon STA
+            "b42e0a4c-ade7-11e4-89d3-123b93f75cba",  # Radon LTA
+        ),
         "BUFFER": "<H5B4H",
-        "SENSOR_FORMAT": (lambda d: {}),
+        "SENSOR_FORMAT": (
+            lambda d: {
+                "humidity": d[6] / 100.0 if d[6] else 0,
+                "temperature": d[7] / 100.0 if d[7] else 0,
+                "radon_sta": d[8],
+                "radon_lta": d[9],
+            }
+        ),
     },
     WaveProduct.WAVE2: {
         "NAME": "Wave (2nd Gen)",
-        "UUID": "b42e4dcc-ade7-11e4-89d3-123b93f75cba",
+        "UUID": ("b42e4dcc-ade7-11e4-89d3-123b93f75cba",),
         "BUFFER": "<4B8H",
         "SENSOR_FORMAT": (
             lambda d: {
@@ -54,7 +66,7 @@ DEVICE = {
     },
     WaveProduct.WAVEMINI: {
         "NAME": "Wave Mini",
-        "UUID": "b42e3b98-ade7-11e4-89d3-123b93f75cba",
+        "UUID": ("b42e3b98-ade7-11e4-89d3-123b93f75cba",),
         "BUFFER": "<HHHHHHLL",
         "SENSOR_FORMAT": (
             lambda d: {

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -51,9 +51,10 @@ def retry(exceptions: Exception, retries: int = 3, delay: int = 1):
                 attempts += 1
                 try:
                     return f(*args, **kwargs)
-                except exceptions:
+                except exceptions as err:
                     if attempts >= retries:
                         raise
+                    _logger.warning(err)
                     sleep(delay)
                     continue
 

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -1,11 +1,14 @@
 import logging
 import struct
 from collections import namedtuple
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
+from datetime import datetime
+from functools import wraps
 from math import log
+from time import sleep
 from typing import Any, Dict, List, Optional, Union
 
-from bleak import BleakClient, discover
+from bleak import BleakClient, BleakError, discover
 from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
 from bleak.backends.device import BLEDevice
 
@@ -32,6 +35,33 @@ class UnsupportedError(Exception):
         super().__init__(self.message)
 
 
+def retry(exceptions: Exception, retries: int = 3, delay: int = 1):
+    """Decorator to gracefully handle raised exceptions.
+
+    :param exceptions: The exceptions to catch
+    :param retries: The amount of times we will retry before raising
+    :param delay: The amount of time in seconds before retrying
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def _retry(*args, **kwargs):
+            attempts = 0
+            while attempts <= retries:
+                attempts += 1
+                try:
+                    return f(*args, **kwargs)
+                except exceptions:
+                    if attempts >= retries:
+                        raise
+                    sleep(delay)
+                    continue
+
+        return _retry
+
+    return decorator
+
+
 @dataclass
 class DeviceSensors:
     """A dataclass to encapsulate sensor data.
@@ -53,15 +83,18 @@ class DeviceSensors:
     pressure: Optional[float] = None
     co2: Optional[float] = None
     voc: Optional[float] = None
-    dew_point: Optional[float] = field(init=False)
+    dew_point: Optional[float] = None
 
     def __post_init__(self):
-        T, RH = self.temperature, self.humidity
-        self.dew_point = round(
-            (243.12 * (log(RH / 100) + ((17.62 * T) / (243.12 + T))))
-            / (17.62 - (log(RH / 100) + ((17.62 * T) / (243.12 + T)))),  # noqa: W503
-            2,
-        )
+        if self.temperature and self.humidity:
+            T, RH = self.temperature, self.humidity
+            self.dew_point = round(
+                (243.12 * (log(RH / 100) + ((17.62 * T) / (243.12 + T))))
+                / (  # noqa: W503
+                    17.62 - (log(RH / 100) + ((17.62 * T) / (243.12 + T)))
+                ),
+                2,
+            )
 
     def __str__(self):
         return f'DeviceSensors ({", ".join(f"{k}: {v}" for k, v in self.as_dict().items())})'
@@ -106,6 +139,7 @@ class WaveDevice:
 
     _client: Optional[BleakClientBlueZDBus] = None
     sensor_readings: Optional[DeviceSensors] = None
+    readings_updated: Optional[datetime] = None
 
     def __init__(self, device: Union[BLEDevice, Any], serial: str):
         self.name: Optional[str] = getattr(device, "name", None)
@@ -116,8 +150,7 @@ class WaveDevice:
 
         self.address: str = device.address  # UUID in MacOS, or MAC in Linux and Windows
         self.serial: str = serial
-        self.model = self.serial[:4]
-        self.product: WaveProduct = WaveProduct(self.model)
+        self.product: WaveProduct = WaveProduct(self.serial[:4])
 
     def __eq__(self, other):
         for prop in ("name", "address", "serial"):
@@ -136,16 +169,17 @@ class WaveDevice:
         except struct.error as err:
             raise UnsupportedError(err, self.name, self.address)
 
-        sensor_version = data[0]
-        if sensor_version != SENSOR_VER_SUPPORTED:
+        if self.product != WaveProduct.WAVE and data[0] != SENSOR_VER_SUPPORTED:  # 💩
             raise UnsupportedError(
-                f"Sensor version ({sensor_version}) != ({SENSOR_VER_SUPPORTED})",
+                f"Sensor version ({data[0]}) != ({SENSOR_VER_SUPPORTED})",
                 self.name,
                 self.address,
             )
         self.sensor_readings = DeviceSensors.from_bytes(data, self.product)
+        self.readings_updated = datetime.utcnow()
         return True
 
+    @retry(BleakError, retries=3, delay=1)
     async def get_sensor_values(self) -> Optional[DeviceSensors]:
         """Connect to Wave device and retrieve Generic Attribute Profile
         (GATT) data. The binary data is handled and mapped to a dataclass.
@@ -154,9 +188,9 @@ class WaveDevice:
         async with BleakClient(self.address) as client:
             self._client: BleakClientBlueZDBus = client
             if self._client and await self._client.is_connected():
-                raw_gatt_data = await client.read_gatt_char(
-                    DEVICE[self.product]["UUID"]
-                )
+                raw_gatt_data = bytearray()
+                for uuid in DEVICE[self.product]["UUID"]:  # type: ignore
+                    raw_gatt_data += await client.read_gatt_char(uuid)
                 self._map_sensor_values(raw_gatt_data)
                 return self.sensor_readings
             else:
@@ -211,11 +245,11 @@ async def discover_devices() -> List[WaveDevice]:
             wave_device = WaveDevice(device, serial)
             wave_devices.append(wave_device)
             _logger.debug(
-                f"Device: {device.name} ({device.address}) identified as a Wave device model {wave_device.model}."
+                f"Device: {device.name} ({device.address}) identified as a Wave device ({wave_device.product})."
             )
         except ValueError:
             _logger.warning(
-                f"Device: {device.name} ({device.address}) is a valid Wave device, but unsupported."
+                f"Device: {device.name} ({device.address}) identified as a Wave device, but unsupported."
             )
             continue
     return wave_devices


### PR DESCRIPTION
## Features
- :sparkles: Add Wave (1st Gen) device support. I don't physically have the device, but was able to work backwards from the buffer format `<H5B4H` and structure accessed from the [example code](https://github.com/Airthings/wave-reader/blob/master/read_wave.py).
- :sparkles: Add `retry` decorator for `WaveDevice.get_sensor_values()` to mitigate transient `BleakError` failures.
- :sparkles: Add `self.readings_updated` to determine when the sensor readings were fetched from the device. 
## Other
- :wastebasket: Removed `self.model` because it seemed redundant with `self.product` already referencing the same value. 
- :white_check_mark: Update testing to cover all changes.
- :white_check_mark: Added more testing around each product's expected `bytearray`, returned by `client.read_gatt_char()`
- :bookmark: Bump to 0.0.5