### PR TITLE
0.0.6 Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,9 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - 'examples/**'
-      - 'README.md'
-      - 'docs/**'
+    paths:
+      - 'wave_reader/**'
+      - 'tests/**'
   pull_request:
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This is an **unofficial** Airthings Wave library designed to provide tools and information
 around device communication. The library wouldn't be possible without the existing scripts
-available by Airthings and contribution of other. We hope to continue making updates through
+available by Airthings and contribution of others. We hope to continue making updates through
 Airthings continued open-source contributions. See [documentation](https://ztroop.github.io/wave-reader-utils/) for more details.
 
 This library uses `bleak` as a dependency instead of `bluepy` for platform cross-compatibility

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,183 @@
+# API Documentation
+
+<a name="wave_reader.wave.WaveDevice"></a>
+## WaveDevice Objects
+
+```python
+class WaveDevice()
+```
+
+An object that represents a Airthings Wave device. The
+``discover_devices`` returns a list of ``BLEDevice`` objects
+that are used in the first parameter.
+
+If you want to instantiate a WaveDevice manually without using
+discovery, you can create a generic object with the following
+properties: ``name``, ``address`` and optionally ``rssi``, ``metadata``.
+
+**Arguments**:
+
+- `device`: Device information from Bleak's discover function
+- `serial`: Parsed serial number from manufacturer data
+
+<a name="wave_reader.wave.WaveDevice.connect"></a>
+#### connect
+
+```python
+ | async connect() -> bool
+```
+
+Method for initiating BLE communication.
+
+<a name="wave_reader.wave.WaveDevice.is_connected"></a>
+#### is_connected
+
+```python
+ | async is_connected() -> bool
+```
+
+Method for determining the status of the BLE connection.
+
+<a name="wave_reader.wave.WaveDevice.disconnect"></a>
+#### disconnect
+
+```python
+ | async disconnect() -> bool
+```
+
+Method for closing BLE communication.
+
+<a name="wave_reader.wave.WaveDevice.read_gatt_descriptor"></a>
+#### read\_gatt\_descriptor
+
+```python
+ | async read_gatt_descriptor(gatt_desc: str) -> bytearray
+```
+
+Read Generic Attribute Profile GATT descriptor data.
+
+**Arguments**:
+
+- `handle`: Manually specify a descriptor UUID.
+
+<a name="wave_reader.wave.WaveDevice.read_gatt_characteristic"></a>
+#### read\_gatt\_characteristic
+
+```python
+ | async read_gatt_characteristic(gatt_char: str) -> bytearray
+```
+
+Read Generic Attribute Profile GATT characteristic data.
+
+**Arguments**:
+
+- `gatt_char`: Manually specify a characteristic UUID.
+
+<a name="wave_reader.wave.WaveDevice.get_services"></a>
+#### get\_services
+
+```python
+ | async get_services() -> Dict
+```
+
+Get available services, descriptors and characteristics for
+the device.
+
+<a name="wave_reader.wave.WaveDevice.get_sensor_values"></a>
+#### get\_sensor\_values
+
+```python
+ | async get_sensor_values() -> Optional[DeviceSensors]
+```
+
+Retrieve sensor values from the specified Wave device.
+
+<a name="wave_reader.wave.WaveDevice.parse_manufacturer_data"></a>
+#### parse\_manufacturer\_data
+
+```python
+ | @staticmethod
+ | parse_manufacturer_data(manufacturer_data: Dict[int, int]) -> Optional[str]
+```
+
+Converts manufacturer data and returns a serial number for the
+Airthings Wave devices.
+
+**Arguments**:
+
+- `manufacturer_data`: The device manufacturer data
+
+<a name="wave_reader.wave.WaveDevice.create"></a>
+#### create
+
+```python
+ | @classmethod
+ | create(cls, address: str, serial: str)
+```
+
+Create a WaveDevice instance with three distinct arguments.
+
+**Arguments**:
+
+- `address`: The device UUID in MacOS, or MAC in Linux and Windows.
+- `serial`: The serial number for the device.
+
+<a name="wave_reader.wave.DeviceSensors"></a>
+## DeviceSensors Objects
+
+```python
+@dataclass
+class DeviceSensors()
+```
+
+A dataclass to encapsulate sensor data.
+
+**Arguments**:
+
+- `humidity`: Relative humidity level (%rH)
+- `radon_sta`: Short-term average for radon level (Bq/m3)
+- `radon_lta`: Long-term average for radon level (Bq/m3)
+- `temperature`: Ambient temperature (degC)
+- `pressure`: Atmospheric pressure (hPa)
+- `co2`: Carbon dioxide level (ppm)
+- `voc`: Volatile organic compound level (ppb)
+- `dew_pont`: Dew point approximation using the Magnus formula (degC)
+
+<a name="wave_reader.wave.DeviceSensors.as_dict"></a>
+#### as\_dict
+
+```python
+ | as_dict() -> Dict[str, Union[int, float]]
+```
+
+Returns a dictionary of populated dataclass fields.
+
+<a name="wave_reader.wave.DeviceSensors.as_tuple"></a>
+#### as\_tuple
+
+```python
+ | as_tuple() -> tuple
+```
+
+Return a tuple of all dataclass fields.
+
+<a name="wave_reader.wave.DeviceSensors.from_bytes"></a>
+#### from\_bytes
+
+```python
+ | @classmethod
+ | from_bytes(cls, data: List[int], product: WaveProduct)
+```
+
+Instantiate the class with raw sensor values and the ``WaveProduct``
+selection. Each product can have different sensors or may require the
+raw data to be handled differently.
+
+<a name="wave_reader.wave.discover_devices"></a>
+## discover\_devices
+
+```python
+async discover_devices() -> List[WaveDevice]
+```
+
+Discovers all valid, accessible Airthings Wave devices.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,26 @@
 # Introduction
 
-This is a community-driven project to provide development tools and resources for the Airthings Wave devices. This wouldn't be possible without the contribution of others.
+![Build Status](https://github.com/ztroop/wave-reader/workflows/Build%20Status/badge.svg)
+[![codecov](https://codecov.io/gh/ztroop/wave-reader-utils/branch/master/graph/badge.svg?token=NG9H8YO1ID)](https://codecov.io/gh/ztroop/wave-reader-utils)
+[![PyPI version](https://badge.fury.io/py/wave-reader.svg)](https://badge.fury.io/py/wave-reader)
+[![Join the chat at https://gitter.im/wave-reader-utils/community](https://badges.gitter.im/wave-reader-utils/community.svg)](https://gitter.im/wave-reader-utils/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The `wave-reader` library uses `bleak` as a dependency instead of `bluepy` for platform cross-compatibility and support for asynchronous operation.
+This is an **unofficial** Airthings Wave library designed to provide tools and information
+around device communication. The library wouldn't be possible without the existing scripts
+available by Airthings and contribution of others.
+
+This library uses `bleak` as a dependency instead of `bluepy` for platform cross-compatibility
+and support for asynchronous operation.
 
 ## Requirements
 
 In Ubuntu Linux, make sure you have `libglib2.0-dev` and `bluez` installed:
 
-```sh
+```
 sudo apt-get install libglib2.0-dev bluez -y
 ```
 
-In theory, other platforms (Windows, Mac) are supported by using bleak as a dependency, but open a ticket if you run into any issues.
+In theory, other platforms (Windows, Mac) _are_ supported by using `bleak` as a dependency, but open a ticket if you run into any issues.
 
 ## Installation
 
@@ -22,7 +30,10 @@ You can install the library by running:
 pip install wave-reader
 ```
 
-## Example
+## Example Usage
+
+There are various concrete examples available in the `examples` directory. This includes
+CLI interaction and other scnearios that demonstrate API usage.
 
 ```python
 import asyncio
@@ -36,14 +47,13 @@ if __name__ == "__main__":
     devices = loop.run_until_complete(discover_devices())
     # Get sensor readings from available wave devices.
     for device in devices:
-        print(device.address, device.serial)
         sensor_readings = loop.run_until_complete(device.get_sensor_values())
         print(sensor_readings)
 
-# Example usage:
-#
-# python basic_usage.py
-#
-# 12:34:56:78:90:AB 2930123456
-# DeviceSensors (humidity: 32.5, radon_sta: 116, radon_lta: 113 ...
+# >>> DeviceSensors (humidity: 32.5, radon_sta: 116, radon_lta: 113 ...
 ```
+
+## Testing
+
+You can run the entire test suite by running `tox`. It will run `flake8`, `isort` and `pytest`.
+If you'd like to just run unit tests, running `pytest ./tests` is sufficient.

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -3,40 +3,42 @@
 While Airthings has been kind enough to provide sample code for interfacing with
 their Wave family of devices, most of the technical details have to be inferred
 from the code or discovered via experimentation. This is an unofficial attempt to
-document those specifications, in hopes that they may be useful to other
-projects.
+document those specifications, in hopes that they may be useful to other projects.
 
 ## Models
 
-| Model | Product Name   | Serial     | Sensors
-| :-----| :----          | :-----     | :------
-| 2900  | Wave           | 2900xxxxxx | radon, temperature, humidity
-| 2920  | Wave Mini      | 2920xxxxxx | temperature, humidity, TVOCs, CO<sub>2</sub>
-| 2930  | Wave Plus      | 2930xxxxxx | radon, temperature, humidity, TVOCs, CO<sub>2</sub>
-| 2950  | Wave (2nd gen) | 2950xxxxxx | radon, temperature, humidity
+| Model    | Product Name   | Serial     | Sensors
+| :---     | :---           | :---       | :---
+| 2900     | Wave           | 2900xxxxxx | radon, temperature, humidity
+| 2920     | Wave Mini      | 2920xxxxxx | temperature, humidity, TVOCs, CO<sub>2</sub>
+| 2930     | Wave Plus      | 2930xxxxxx | radon, temperature, humidity, TVOCs, CO<sub>2</sub>
+| 2950     | Wave (2nd gen) | 2950xxxxxx | radon, temperature, humidity
+| 2940     | Wave Mist      | 2940xxxxxx | ?
+| 2810     | Wave Hub       | 2810xxxxxx | ?
+| 2820     | Wave Hub       | 2820xxxxxx | ?
 
 ## Bluetooth Low Energy (BLE)
 
-### BLE Advertisement
+## BLE Advertisement
 
 A standard BLE advertisement contains 4 attributes: `name`, `address`, `rssi`, and `metadata`.
 
-#### BLE Advertisement - Name
+### BLE Advertisement - Name
 
 The `name` attribute *may* be populated with an Airthings name based on the model.
 
-| Model | BLE Advertised Name
-| :-----| :----
-| 2900  | Airthings Wave (not verified)
-| 2920  | Airthings Wave Mini (not verified)
-| 2930  | Airthings Wave+
-| 2950  | Airthings Wave2
+| Model  | BLE Advertised Name
+| :---   | :---
+| 2900   | Airthings Wave (not verified)
+| 2920   | Airthings Wave Mini (not verified)
+| 2930   | Airthings Wave+
+| 2940   | Airthings Wave Mist (not verified)
+| 2950   | Airthings Wave2
 
 Advertisements are **not guaranteed** to be populated with this descriptive
-name, possibly appearing as a variant of the MAC address (e.g.
-`12-34-56-78-90-AD`).
+name, possibly appearing as a variant of the MAC address (e.g. `12-34-56-78-90-AD`).
 
-#### BLE Advertisement - Metadata
+### BLE Advertisement - Metadata
 
 The standard BLE `metadata` attribute consists of two sub-attributes:
 
@@ -57,21 +59,31 @@ This ID is registered to `Corentium AS`.
 
 The manufacturer data under this ID contains the device serial number. See [Data Formats](#ble-manufacturer-data)
 
-### BLE Services
+## BLE Services
 
-Wave devices expose multiple BLE services.
+**Wave+**
 
 | Service UUID                         | Description                      | Notes                       |
 | :---                                 | :---                             | :---                        |
 | 00001801-0000-1000-8000-00805f9b34fb | Generic Attribute Profile        |                             |
 | 0000180a-0000-1000-8000-00805f9b34fb | Device Information               |                             |
 | f000ffc0-0451-4000-b000-000000000000 | TI Over-the-Air Download Service | Likely Firmware Related     |
-| b42e4a8e-ade7-11e4-89d3-123b93f75cba | Airthings                        | Wave2 only                  |
-| b42e1c08-ade7-11e4-89d3-123b93f75cba | Airthings                        | Wave+ only                  |
+| b42e1c08-ade7-11e4-89d3-123b93f75cba | Unknown (Airthings)              | Wave+                       |
 
-### BLE Characteristics
+**Wave2**
 
-#### Standard BLE Device Information
+| Service UUID                         | Description                      | Notes                       |
+| :---                                 | :---                             | :---                        |
+| 00001801-0000-1000-8000-00805f9b34fb | Generic Attribute Profile        |                             |
+| 0000180a-0000-1000-8000-00805f9b34fb | Device Information               |                             |
+| f000ffc0-0451-4000-b000-000000000000 | TI Over-the-Air Download Service | Likely Firmware Related     |
+| b42e4a8e-ade7-11e4-89d3-123b93f75cba | Airthings                        | Wave2                       |
+
+## BLE Characteristics
+
+### Device Information Service
+
+The ``characteristic`` UUIDs seem to be consistent on Wave2 and Wave+ devices.
 
 | Characteristic UUID                  | Actions | Name                     | Value / Example               |
 | :---                                 | :---    | :---                     | :---                          |
@@ -84,19 +96,35 @@ Wave devices expose multiple BLE services.
 
 When combined, the `Model Number String` and `Serial Number String` appear to match the information provided in the BLE metadata `manufacturer_data`, as well as the serial printed on the physical device.
 
-#### Airthings Wave Devices
+### Airthings Service
+
+**Wave+**
 
 | Characteristic UUID                  | Actions                                 | Description               |
 | :---                                 | :---                                    | :---                      |
+| b42e2fc2-ade7-11e4-89d3-123b93f75cba | notify                                  |                           |
+| b42e2d06-ade7-11e4-89d3-123b93f75cba | write-without-reponse, write, indicate  |                           |
 | b42e2a68-ade7-11e4-89d3-123b93f75cba | read                                    | Wave+ current readings    |
-| b42e2fc2-ade7-11e4-89d3-123b93f75cba | notify                                  | Wave+                     |
-| b42e2d06-ade7-11e4-89d3-123b93f75cba | write-without-response, write, indicate | Wave+                     |
-| b42e4dcc-ade7-11e4-89d3-123b93f75cba | read                                    | Wave2 current readings    |
-| b42e50d8-ade7-11e4-89d3-123b93f75cba | write, notify                           | Wave2                     |
-| b42e538a-ade7-11e4-89d3-123b93f75cba | notify                                  | Wave2                     |
-| b42e3b98-ade7-11e4-89d3-123b93f75cba | read                                    | WaveMini current readings |
 
-#### TI OTA
+**Wave2**
+
+| Characteristic UUID                  | Actions                                 | Description               |
+| :---                                 | :---                                    | :---                      |
+| b42e538a-ade7-11e4-89d3-123b93f75cba | notify                                  |                           |
+| b42e50d8-ade7-11e4-89d3-123b93f75cba | write, notify                           |                           |
+| b42e4dcc-ade7-11e4-89d3-123b93f75cba | read                                    | Wave2 current readings    |
+
+### TI Over-the-Air Download Service
+
+**Wave+**
+
+| Characteristic UUID                  | Actions                               | Description |
+| :---                                 | :---                                  | :---        |
+| f000ffc5-0451-4000-b000-000000000000 | write-without-response, notify        | ?           |
+| f000ffc2-0451-4000-b000-000000000000 | write-without-response, write, notify | ?           |
+| f000ffc1-0451-4000-b000-000000000000 | write-without-response, write, notify | ?           |
+
+**Wave2**
 
 | Characteristic UUID                  | Actions       | Description |
 | :---                                 | :---          | :---        |
@@ -104,11 +132,11 @@ When combined, the `Model Number String` and `Serial Number String` appear to ma
 | f000ffc2-0451-4000-b000-000000000000 | write, notify | ?           |
 | f000ffc1-0451-4000-b000-000000000000 | write, notify | ?           |
 
-## Data Formats
+# Data Format
 
 All binary data appears to be little-endian.
 
-### BLE Manufacturer Data
+## BLE Manufacturer Data
 
 The BLE advertisement's manufacturer data for Airthings devices (id: 820) encodes the device serial number, which itself embeds the device model.
 
@@ -119,10 +147,20 @@ The BLE advertisement's manufacturer data for Airthings devices (id: 820) encode
 | 0-3  | serial | uint32 | e.g. `0x6DE1D5AF` | decimal: `2950029677` --> model 2950 (Wave2) |
 | 4-5  | --     | --     | `0x0900`          | unknown, may vary                            |
 
-### Wave (2900) Sensor Format
-### Wave Mini (2920) Sensor Format
-### Wave+ (2930) Sensor Format
-### Wave2 (2950) Sensor Format
+## Sensor Values
+
+**Wave+**
+
+Reading BLE characteristic `b42e4dcc-ade7-11e4-89d3-123b93f75cba` returns a 20 byte value representing the current sensor values.
+
+```
+00000000: 3031 2034 3120 3030 2030 3020 3838 2030  01 41 00 00 88 0
+00000010: 3020 3866 2030 3020 3066 2030 3820 3538  0 8f 00 0f 08 58
+00000020: 2062 6620 6234 2030 3220 3732 2030 3020   bf b4 02 72 00
+00000030: 3030 2030 3020 3163 2030 360a            00 00 1c 06.
+```
+
+**Wave2**
 
 Reading BLE characteristic `b42e4dcc-ade7-11e4-89d3-123b93f75cba` returns a 20 byte value representing the current sensor values.
 
@@ -136,29 +174,9 @@ Reading BLE characteristic `b42e4dcc-ade7-11e4-89d3-123b93f75cba` returns a 20 b
 | 8-9   | temperature | uint16 | temp = val/100 (celsius)                    |
 | 10-19 | --          | --     | unknown, always `0xFFFFFFFFFFFF0000FFFF`    |
 
-#### Sample Values
-
 ```
-      0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19
-#1 : 01 35 1d 00 28 00 3A 00 a2 07 ff ff ff ff ff ff 00 00 ff ff
-#2 : 01 35 21 00 28 00 3A 00 9f 07 ff ff ff ff ff ff 00 00 ff ff
-#3 : 01 35 3F 00 27 00 3A 00 96 07 ff ff ff ff ff ff 00 00 ff ff
-```
-
-Above sample for `#3`:
-
-```
-version = 1
-relative humidity = 26.5%
-short-term radon = 39 Bq^3
-long-term radon = 58 Bq^3
-temperature = 19.42°C
-```
-
-## Firmware Revisions
-
-### Wave2
-```
-G-BLE-1.4.5-beta+0
-G-BLE-1.5.3-master+0
+00000000: 3031 2033 3520 3164 2030 3020 3238 2030  01 35 1d 00 28 0
+00000010: 3020 3341 2030 3020 6132 2030 3720 6666  0 3A 00 a2 07 ff
+00000020: 2066 6620 6666 2066 6620 6666 2066 6620   ff ff ff ff ff
+00000030: 3030 2030 3020 6666 2066 660a            00 00 ff ff.
 ```

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,6 +1,9 @@
 import asyncio
+import logging
 
 from wave_reader import discover_devices
+
+logging.basicConfig(level=logging.DEBUG)
 
 if __name__ == "__main__":
     # Event loop to run asynchronous tasks.

--- a/examples/cli_usage.py
+++ b/examples/cli_usage.py
@@ -34,8 +34,11 @@ async def run(args):
 
     async with WaveDevice.create(args.address, args.serial) as conn:
         if args.characteristic:
-            c = await conn.get_gatt_char(args.characteristic)
+            c = await conn.read_gatt_char(args.characteristic)
             console.print(simple_table("Characteristic", c.hex(" ")))
+        elif args.descriptor:
+            c = await conn.read_gatt_descriptor(args.descriptor)
+            console.print(simple_table("Descriptor", c.hex(" ")))
         else:
             await conn.get_sensor_values()
             console.print(data_table(conn.sensor_readings.as_dict(), conn.serial))
@@ -46,6 +49,7 @@ if __name__ == "__main__":
     parser.add_argument("-a", "--address", help="Device address", required=True)
     parser.add_argument("-s", "--serial", help="Device serial number", required=True)
     parser.add_argument("-c", "--characteristic", help="Get characteristic")
+    parser.add_argument("-d", "--descriptor", help="Get descriptor")
 
     args = parser.parse_args()
     loop = asyncio.get_event_loop()

--- a/examples/get_services.py
+++ b/examples/get_services.py
@@ -1,0 +1,23 @@
+import argparse
+import asyncio
+import logging
+
+from wave_reader.wave import WaveDevice
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+async def run(args):
+    async with WaveDevice.create(args.address, args.serial) as conn:
+        services = await conn.get_services()
+        return services
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Wave sensor readings")
+    parser.add_argument("-a", "--address", help="Device address", required=True)
+    parser.add_argument("-s", "--serial", help="Device serial number", required=True)
+
+    args = parser.parse_args()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run(args))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     author='Zackary Troop',
     name='wave-reader',
-    version='0.0.5',
+    version='0.0.6',
     url='https://github.com/ztroop/wave-reader-utils',
     license='MIT',
     description='Unofficial package for Airthings Wave communication.',

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -44,3 +44,9 @@ class MockedBleakClient(object):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.disconnect()
         return True
+
+
+class MockedFailingBleakClient(MockedBleakClient):
+    async def connect(self):
+        self._is_connected = False
+        return False

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -61,14 +61,14 @@ class TestWaveDevice(IsolatedAsyncioTestCase):
         Wave device."""
 
         BLEUnsupportedDevice = deepcopy(self.BLEDevice)
-        # manufacturer data represents serial '2862618893', indicating invalid model '2862'
+        # Manufacturer data represents serial '2862618893', indicating invalid model '286'
         BLEUnsupportedDevice.metadata["manufacturer_data"] = {
             820: [13, 25, 160, 170, 9, 0]
         }
 
         mocked_discover.return_value = [BLEUnsupportedDevice]
         devices = await wave.discover_devices()
-        self.assertFalse(devices)
+        self.assertEqual(devices[0].product, data.WaveProduct.UNKNOWN)
         self.assertTrue(mocked_logger.called)
 
     @patch("wave_reader.wave.discover")
@@ -117,11 +117,12 @@ class TestWaveDevice(IsolatedAsyncioTestCase):
         self.assertEqual(device.address, "12:34:56:78:90:AB")
         self.assertEqual(device.serial, "2900123456")
 
-    def test_create_invalid_product(self):
-        """Test ValueError exception is raised when a unsupported product is specified."""
+    @patch("wave_reader.wave._logger.warning")
+    def test_create_invalid_product(self, mocked_logger):
+        """Test warning is sent when a unsupported product is specified."""
 
-        with self.assertRaises(ValueError):
-            wave.WaveDevice.create("12:34:56:78:90:AB", "123")
+        wave.WaveDevice.create("12:34:56:78:90:AB", "123")
+        self.assertTrue(mocked_logger.called)
 
     @patch("wave_reader.wave._logger.error")
     def test_invalid_map_sensor_values(self, mocked_logger):

--- a/wave_reader/data.py
+++ b/wave_reader/data.py
@@ -2,10 +2,13 @@ from enum import Enum
 
 
 class WaveProduct(Enum):
-    WAVE = "2900"
-    WAVEMINI = "2920"
-    WAVEPLUS = "2930"
-    WAVE2 = "2950"
+    WAVE = "290"
+    WAVE2 = "295"
+    WAVEPLUS = "293"
+    WAVEMINI = "292"
+    WAVEMIST = "294"
+    UNKNOWN = ""
+    # HUB = ["281", "282"]
 
 
 # Company Identifier registered with the Bluetooth SIG
@@ -21,7 +24,7 @@ DEVICE = {
         "NAME": "Wave+",
         "UUID": ("b42e2a68-ade7-11e4-89d3-123b93f75cba",),
         "BUFFER": "<BBBBHHHHHHHH",
-        "SENSOR_FORMAT": (
+        "DATA_FORMAT": (
             lambda d: {
                 "humidity": d[1] / 2.0 if d[1] else 0,
                 "radon_sta": d[4],
@@ -42,7 +45,7 @@ DEVICE = {
             "b42e0a4c-ade7-11e4-89d3-123b93f75cba",  # Radon LTA
         ),
         "BUFFER": "<H5B4H",
-        "SENSOR_FORMAT": (
+        "DATA_FORMAT": (
             lambda d: {
                 "humidity": d[6] / 100.0 if d[6] else 0,
                 "temperature": d[7] / 100.0 if d[7] else 0,
@@ -55,7 +58,7 @@ DEVICE = {
         "NAME": "Wave (2nd Gen)",
         "UUID": ("b42e4dcc-ade7-11e4-89d3-123b93f75cba",),
         "BUFFER": "<4B8H",
-        "SENSOR_FORMAT": (
+        "DATA_FORMAT": (
             lambda d: {
                 "humidity": d[1] / 2.0 if d[1] else 0,
                 "radon_sta": d[4],
@@ -68,12 +71,18 @@ DEVICE = {
         "NAME": "Wave Mini",
         "UUID": ("b42e3b98-ade7-11e4-89d3-123b93f75cba",),
         "BUFFER": "<HHHHHHLL",
-        "SENSOR_FORMAT": (
+        "DATA_FORMAT": (
             lambda d: {
                 "temperature": round(d[1] / 100.0 - 273.15 if d[1] else 0, 2),
                 "humidity": d[3] / 100.0 if d[3] else 0,
                 "voc": d[4],
             }
         ),
+    },
+    WaveProduct.UNKNOWN: {
+        "NAME": "Unknown",
+        "UUID": tuple(),
+        "BUFFER": "",
+        "DATA_FORMAT": lambda _: _,
     },
 }

--- a/wave_reader/data.py
+++ b/wave_reader/data.py
@@ -6,8 +6,8 @@ class WaveProduct(Enum):
     WAVE2 = "295"
     WAVEPLUS = "293"
     WAVEMINI = "292"
-    WAVEMIST = "294"
     UNKNOWN = ""
+    # WAVEMIST = "294"
     # HUB = ["281", "282"]
 
 

--- a/wave_reader/utils.py
+++ b/wave_reader/utils.py
@@ -1,0 +1,68 @@
+import logging
+from functools import wraps
+from time import sleep
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+
+class UnsupportedError(Exception):
+    """Custom exception class for unsupported device errors.
+
+    :param message: The error message
+    :param name: The device name
+    :param addr: The device address (UUID in MacOS, MAC in Linux/Windows)
+    """
+
+    def __init__(self, message: str, addr: str):
+        self.message = f"Device: ({addr}) -> {message}"
+        _logger.error(self.message)
+        super().__init__(self.message)
+
+
+def retry(exceptions: Any, retries: int, delay: int):
+    """Decorator to gracefully handle and retry raised exceptions.
+
+    :param exceptions: The exceptions to catch
+    :param retries: The amount of times we will retry before raising
+    :param delay: The amount of time in seconds before retrying
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def _retry(*args, **kwargs):
+            attempts = 0
+            while attempts <= retries:
+                attempts += 1
+                try:
+                    return f(*args, **kwargs)
+                except exceptions as err:
+                    if attempts >= retries:
+                        raise
+                    _logger.error(err)
+                    sleep(delay)
+                    continue
+
+        return _retry
+
+    return decorator
+
+
+def requires_client(f):
+    """Decorator that verifies the existance of the client implementation."""
+
+    @wraps(f)
+    async def _requires_client(self, *args, **kwargs):
+        reconnects = 0
+
+        while not self._client or not await self._client.is_connected():
+            _logger.error(f"Device: ({self.address}) client is not connected.")
+            await self.connect()
+
+            reconnects += 1
+            if reconnects > 3:
+                return
+
+        return await f(self, *args, **kwargs)
+
+    return _requires_client


### PR DESCRIPTION
## 0.0.6 Changes
### Highlights

- :memo: Add `logging` to `basic_usage.py` example.
- :hammer: Change `[:4]` to `[:3]` to be consistent with Airthings Wave mobile application.
- :hammer: Instantiating an unknown `WaveProduct` when `WaveDevice` is instantiated will no longer occur.
- :sparkles: Add `WAVEMIST` and `UNKNOWN` to `WaveProduct`.
- :sparkles: Add `READER_RETRY` and `READER_RETRY_DELAY` environment variables to override `retry()` parameters.
- :sparkles: Add `connect()`, `is_connected()`, `disconnect()`, and `get_services()`.
- :sparkles: Add `read_gatt_characteristics()` and `read_gatt_descriptors()`.
- :memo: Update docs. Add `API Documentation`.

### Description

- After some investigation, I was able to determine what the _Airthings Wave_ mobile app is doing to determine what the Wave product is. It looks like it uses the first 3 numbers of the serial. I was also able to determine what the values were for the Hub and Wave Mist (It appears to be a variant of Wave Mini?)
- To provide better robustness, valid Wave devices that are not supported will not throw an error. Instead, the `WaveProduct` referenced will be `UNKNOWN`. The intent here is that the user can still run available methods to obtain more information about the device.
- `get_services()` will provide more information to users that are interested in getting the available services, descriptors and characteristics of the device. The `connect()` and `disconnect()` methods will allow for longer lived and manual handling of connections. The convenience method `get_sensor_values()` will run `disconnect()` after operation to avoid lingering connections.