### PR TITLE
:bookmark: 1.0.0 Release

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -4,7 +4,7 @@ from wave_reader.wave import WaveDevice
 
 from wave_reader import discover_devices
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 
 async def get_readings(device: WaveDevice) -> None:
@@ -15,7 +15,7 @@ async def get_readings(device: WaveDevice) -> None:
 
 if __name__ == "__main__":
     # Event loop to run asynchronous tasks.
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     # Scan for BTLE Wave devices.
     devices = loop.run_until_complete(discover_devices(timeout=5.0))
     # Get sensor readings from available wave devices.

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     # Event loop to run asynchronous tasks.
     loop = asyncio.get_event_loop()
     # Scan for BTLE Wave devices.
-    devices = loop.run_until_complete(discover_devices())
+    devices = loop.run_until_complete(discover_devices(timeout=5.0))
     # Get sensor readings from available wave devices.
     for device in devices:
         loop.run_until_complete(get_readings(device))

--- a/examples/cli_usage.py
+++ b/examples/cli_usage.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--descriptor", help="Get descriptor")
 
     args = parser.parse_args()
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(run(args))
 
 

--- a/examples/get_services.py
+++ b/examples/get_services.py
@@ -19,5 +19,5 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--serial", help="Device serial number", required=True)
 
     args = parser.parse_args()
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(run(args))

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["examples", "tests"]),
     install_requires=[
-        "Authlib>=0.15.4",
-        "bleak>=0.10.0",
+        "Authlib>=0.15.6",
+        "bleak>=0.19.5",
         "httpx>=0.18.2",
     ],
     python_requires=">=3.7.*",
@@ -23,5 +23,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     author="Zackary Troop",
     name="wave-reader",
-    version="0.0.10",
+    version="1.0.0",
     url="https://github.com/ztroop/wave-reader-utils",
     license="MIT",
     description="Unofficial package for Airthings Wave communication.",

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -34,7 +34,7 @@ class TestWaveDevice(IsolatedAsyncioTestCase):
         self.WaveDevice = wave.WaveDevice(self.BLEDevice, "2930618893")
 
     @patch("wave_reader.wave._logger.debug")
-    @patch("wave_reader.wave.discover")
+    @patch("wave_reader.wave.BleakScanner.discover")
     async def test_discover_devices(self, mocked_discover, mocked_logger):
         """Test device discovery, omitting invalid or unknown devices."""
 
@@ -56,7 +56,7 @@ class TestWaveDevice(IsolatedAsyncioTestCase):
         self.assertTrue(mocked_logger.called)
 
     @patch("wave_reader.wave._logger.warning")
-    @patch("wave_reader.wave.discover")
+    @patch("wave_reader.wave.BleakScanner.discover")
     async def test_unsupported_discover_devices(self, mocked_discover, mocked_logger):
         """Test device discovery, emit a warning for a detected, but unsupported
         Wave device."""
@@ -72,7 +72,7 @@ class TestWaveDevice(IsolatedAsyncioTestCase):
         self.assertEqual(devices[0].product, data.WaveProduct.UNKNOWN)
         self.assertTrue(mocked_logger.called)
 
-    @patch("wave_reader.wave.discover")
+    @patch("wave_reader.wave.BleakScanner.discover")
     async def test_discover_valid_unnamed_device(self, mocked_discover):
         """Test device discovery when the BLE advertisement does not include the model name."""
         BLEUnnamedDevice = deepcopy(self.BLEDevice)
@@ -230,7 +230,7 @@ class TestScan(TestCase):
         self.BLEDevice = MockedBLEDevice()
         self.WaveDevice = wave.WaveDevice(self.BLEDevice, "2930618893")
 
-    @patch("wave_reader.wave.discover")
+    @patch("wave_reader.wave.BleakScanner.discover")
     def test_scan(self, mocked_discover):
         mocked_discover.return_value = [self.WaveDevice]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist = flake8,isort,mypy,coverage
 
 [testenv]
-passenv = PYTHONPATH HOME DISPLAY
-setenv = PYTHONDONTWRITEBYTECODE=1
 basepython = python3
 deps = pytest
        flake8

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -159,9 +159,9 @@ class WaveDevice:
     async def connect(self) -> bool:
         """Method for initiating BLE connection."""
 
-        self._client: BaseBleakClient = BleakClient(self.address)
+        self._client = BleakClient(self.address)  # type: ignore
         _logger.info(f"Device: ({self.address}) connecting BLE client.")
-        return await self._client.connect()
+        return await self._client.connect() if self._client else False
 
     @requires_client
     async def is_connected(self) -> bool:
@@ -174,7 +174,7 @@ class WaveDevice:
         """Method for closing BLE connection."""
 
         _logger.info(f"Device: ({self.address}) disconnecting BLE client.")
-        return await self._client.disconnect()  # type: ignore
+        return await self._client.disconnect() if self._client else False
 
     @requires_client
     async def read_gatt_descriptor(self, gatt_desc: str) -> Optional[bytearray]:

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from math import log
 from typing import Any, Dict, List, Optional, Union
 
-from bleak import BleakClient, discover
+from bleak import BleakClient, BleakScanner
 from bleak.backends.client import BaseBleakClient
 from bleak.backends.device import BLEDevice
 
@@ -250,13 +250,13 @@ class WaveDevice:
 
 
 async def discover_devices(
-    wave_devices: Optional[List[WaveDevice]] = None,
+    wave_devices: Optional[List[WaveDevice]] = None, **kwargs
 ) -> List[WaveDevice]:
     """Discovers all valid, accessible Airthings Wave devices."""
 
     wave_devices = wave_devices if isinstance(wave_devices, list) else []
     device: BLEDevice  # Typing annotation
-    for device in await discover():
+    for device in await BleakScanner.discover(**kwargs):
         serial = WaveDevice.parse_manufacturer_data(
             device.metadata.get("manufacturer_data")
         )
@@ -269,7 +269,7 @@ async def discover_devices(
     return wave_devices
 
 
-def scan(max_retries: int = 3) -> List[WaveDevice]:
+def scan(max_retries: int = 3, **kwargs) -> List[WaveDevice]:
     """Convenience function for discovering devices. This is particularly useful
     for users that are not as comfortable asynchronous programming.
 
@@ -281,7 +281,7 @@ def scan(max_retries: int = 3) -> List[WaveDevice]:
 
     def _scan():
         loop = asyncio.new_event_loop()
-        task = loop.create_task(discover_devices(wave_devices))
+        task = loop.create_task(discover_devices(wave_devices, **kwargs))
         tasks = asyncio.gather(task, return_exceptions=True)
         loop.run_until_complete(tasks)
 

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -250,13 +250,17 @@ class WaveDevice:
 
 
 async def discover_devices(
-    wave_devices: Optional[List[WaveDevice]] = None, **kwargs
+    wave_devices: Optional[List[WaveDevice]] = None, timeout=5.0, **kwargs
 ) -> List[WaveDevice]:
-    """Discovers all valid, accessible Airthings Wave devices."""
+    """Discovers all valid, accessible Airthings Wave devices.
+
+    :param wave_devices: List to return devices from asyncio task
+    :param timeout: Scanning timeout in seconds (Default: 5.0)
+    """
 
     wave_devices = wave_devices if isinstance(wave_devices, list) else []
     device: BLEDevice  # Typing annotation
-    for device in await BleakScanner.discover(**kwargs):
+    for device in await BleakScanner.discover(timeout=timeout, **kwargs):
         serial = WaveDevice.parse_manufacturer_data(
             device.metadata.get("manufacturer_data")
         )
@@ -269,11 +273,12 @@ async def discover_devices(
     return wave_devices
 
 
-def scan(max_retries: int = 3, **kwargs) -> List[WaveDevice]:
+def scan(max_retries: int = 3, timeout=5.0, **kwargs) -> List[WaveDevice]:
     """Convenience function for discovering devices. This is particularly useful
     for users that are not as comfortable asynchronous programming.
 
     :param max_retries: Number of attempts for connecting to devices
+    :param timeout: Scanning timeout in seconds (Default: 5.0)
     """
 
     retry_attempts = 0
@@ -281,7 +286,8 @@ def scan(max_retries: int = 3, **kwargs) -> List[WaveDevice]:
 
     def _scan():
         loop = asyncio.new_event_loop()
-        task = loop.create_task(discover_devices(wave_devices, **kwargs))
+        task = loop.create_task(
+            discover_devices(wave_devices, timeout=timeout, **kwargs))
         tasks = asyncio.gather(task, return_exceptions=True)
         loop.run_until_complete(tasks)
 


### PR DESCRIPTION
I think it's safe to say this is out of a beta release. 😄 

- **Maintenance:** The `bleak` dependency change from `0.10.0` to `0.19.5`.
- **Maintenance:** Use `BleakScanner.discover()` method instead of deprecated `discover()` function.
- **Feature:** Add `timeout` keyword argument into scanning methods.
- **Feature:** Allow `**kwargs` to be passed into scanning methods.