### PR TITLE
add support for View Plus device

### DIFF
--- a/wave_reader/data.py
+++ b/wave_reader/data.py
@@ -4,6 +4,7 @@ from enum import Enum
 class WaveProduct(Enum):
     WAVE = "290"
     WAVE2 = "295"
+    VIEWPLUS = "296"
     WAVEPLUS = "293"
     WAVEMINI = "292"
     UNKNOWN = ""

--- a/wave_reader/wave.py
+++ b/wave_reader/wave.py
@@ -35,7 +35,8 @@ class DeviceSensors:
     :param pressure: Atmospheric pressure (hPa)
     :param co2: Carbon dioxide level (ppm)
     :param voc: Volatile organic compound level (ppb)
-    :param pm: Particulate matter (ug/m3)
+    :param pm1: Particulate matter 1 (ug/m3)
+    :param pm2_5: Particulate matter 2.5 (ug/m3)
     """
 
     humidity: Optional[Humidity] = None
@@ -45,7 +46,8 @@ class DeviceSensors:
     pressure: Optional[Pressure] = None
     co2: Optional[CO2] = None
     voc: Optional[VOC] = None
-    pm: Optional[PM] = None
+    pm1: Optional[PM] = None
+    pm2_5: Optional[PM] = None
 
     def __str__(self):
         return f'DeviceSensors ({", ".join(f"{k}: {v}" for k, v in self.as_dict().items())})'
@@ -114,6 +116,7 @@ class WaveDevice:
             device, "metadata", None
         )
 
+        print(f"{self.metadata=}")
         self.address: str = device.address  # UUID in MacOS, or MAC in Linux and Windows
         self.serial: str = serial
         try:
@@ -146,6 +149,8 @@ class WaveDevice:
             data: List[int] = struct.unpack(DEVICE[self.product]["BUFFER"], gatt_data)  # type: ignore
         except struct.error as err:
             raise UnsupportedError(str(err), self.address)
+
+        print(f"{gatt_data=}")
 
         if self.product != WaveProduct.WAVE and data[0] != SENSOR_VER_SUPPORTED:  # 💩
             raise UnsupportedError(


### PR DESCRIPTION
hoping to address #10 :)  

I started by determining the device address, finding the model code (`2960`) and using `service_explorer.py` from `bleak` to map out the characteristic UUIDs:

```
~/src/bleak (develop) » python examples/service_explorer.py --address "F8:55:48:9B:62:E8"
2022-12-31 18:04:36,291 __main__ INFO: starting scan...
2022-12-31 18:04:40,416 __main__ INFO: connecting to device...
2022-12-31 18:04:41,652 __main__ INFO: connected
2022-12-31 18:04:41,652 __main__ INFO: [Service] f000ffc0-0451-4000-b000-000000000000 (Handle: 13): Unknown
2022-12-31 18:04:41,652 __main__ INFO:   [Characteristic] f000ffc2-0451-4000-b000-000000000000 (Handle: 18): Unknown (write-without-response,write,notify)
2022-12-31 18:04:41,728 __main__ INFO:     [Descriptor] 00002901-0000-1000-8000-00805f9b34fb (Handle: 21): Characteristic User Description, Value: bytearray(b'Img Block')
2022-12-31 18:04:41,758 __main__ INFO:     [Descriptor] 00002902-0000-1000-8000-00805f9b34fb (Handle: 20): Client Characteristic Configuration, Value: bytearray(b'\x00\x00')
2022-12-31 18:04:41,758 __main__ INFO:   [Characteristic] f000ffc1-0451-4000-b000-000000000000 (Handle: 14): Unknown (write-without-response,write,notify)
2022-12-31 18:04:41,788 __main__ INFO:     [Descriptor] 00002901-0000-1000-8000-00805f9b34fb (Handle: 17): Characteristic User Description, Value: bytearray(b'Img Identify')
2022-12-31 18:04:41,818 __main__ INFO:     [Descriptor] 00002902-0000-1000-8000-00805f9b34fb (Handle: 16): Client Characteristic Configuration, Value: bytearray(b'\x00\x00')
2022-12-31 18:04:41,818 __main__ INFO:   [Characteristic] f000ffc5-0451-4000-b000-000000000000 (Handle: 22): Unknown (write-without-response,notify)
2022-12-31 18:04:41,847 __main__ INFO:     [Descriptor] 00002901-0000-1000-8000-00805f9b34fb (Handle: 25): Characteristic User Description, Value: bytearray(b'OAD Extended Control')
2022-12-31 18:04:41,892 __main__ INFO:     [Descriptor] 00002902-0000-1000-8000-00805f9b34fb (Handle: 24): Client Characteristic Configuration, Value: bytearray(b'\x00\x00')
2022-12-31 18:04:41,892 __main__ INFO: [Service] b42eb4a6-ade7-11e4-89d3-123b93f75cba (Handle: 41): Unknown
2022-12-31 18:04:41,892 __main__ INFO:   [Characteristic] b42ebc9e-ade7-11e4-89d3-123b93f75cba (Handle: 50): Unknown (notify)
2022-12-31 18:04:41,922 __main__ INFO:     [Descriptor] 00002902-0000-1000-8000-00805f9b34fb (Handle: 53): Client Characteristic Configuration, Value: bytearray(b'\x00\x00')
2022-12-31 18:04:41,953 __main__ INFO:     [Descriptor] 00002901-0000-1000-8000-00805f9b34fb (Handle: 52): Characteristic User Description, Value: bytearray(b'Status')
2022-12-31 18:04:41,953 __main__ INFO:   [Characteristic] b42eb9f6-ade7-11e4-89d3-123b93f75cba (Handle: 46): Unknown (write)
2022-12-31 18:04:41,983 __main__ INFO:     [Descriptor] 00002902-0000-1000-8000-00805f9b34fb (Handle: 49): Client Characteristic Configuration, Value: bytearray(b'\x00\x00')
2022-12-31 18:04:42,013 __main__ INFO:     [Descriptor] 00002901-0000-1000-8000-00805f9b34fb (Handle: 48): Characteristic User Description, Value: bytearray(b'Closed Control Point')
2022-12-31 18:04:42,013 __main__ INFO:   [Characteristic] b42eb73a-ade7-11e4-89d3-123b93f75cba (Handle: 42): Unknown (write)
2022-12-31 18:04:42,043 __main__ INFO:     [Descriptor] 00002901-0000-1000-8000-00805f9b34fb (Handle: 44): Characteristic User Description, Value: bytearray(b'Open Control Point')
2022-12-31 18:04:42,073 __main__ INFO:     [Descriptor] 00002902-0000-1000-8000-00805f9b34fb (Handle: 45): Client Characteristic Configuration, Value: bytearray(b'\x00\x00')
2022-12-31 18:04:42,073 __main__ INFO: [Service] 00001801-0000-1000-8000-00805f9b34fb (Handle: 12): Generic Attribute Profile
2022-12-31 18:04:42,073 __main__ INFO: [Service] 0000180a-0000-1000-8000-00805f9b34fb (Handle: 26): Device Information
2022-12-31 18:04:42,103 __main__ INFO:   [Characteristic] 00002a26-0000-1000-8000-00805f9b34fb (Handle: 33): Firmware Revision String (read), Value: bytearray(b'A-BLE-1.8.0-master+0')
2022-12-31 18:04:42,133 __main__ INFO:   [Characteristic] 00002a25-0000-1000-8000-00805f9b34fb (Handle: 31): Serial Number String (read), Value: bytearray(b'038481')
2022-12-31 18:04:42,163 __main__ INFO:   [Characteristic] 00002a28-0000-1000-8000-00805f9b34fb (Handle: 37): Software Revision String (read), Value: bytearray(b'0.0.0')
2022-12-31 18:04:42,193 __main__ INFO:   [Characteristic] 00002a23-0000-1000-8000-00805f9b34fb (Handle: 27): System ID (read), Value: bytearray(b'\xe8b\x9b\x00\x00HU\xf8')
2022-12-31 18:04:42,223 __main__ INFO:   [Characteristic] 00002a29-0000-1000-8000-00805f9b34fb (Handle: 39): Manufacturer Name String (read), Value: bytearray(b'Airthings AS')
2022-12-31 18:04:42,253 __main__ INFO:   [Characteristic] 00002a24-0000-1000-8000-00805f9b34fb (Handle: 29): Model Number String (read), Value: bytearray(b'2960')
2022-12-31 18:04:42,283 __main__ INFO:   [Characteristic] 00002a27-0000-1000-8000-00805f9b34fb (Handle: 35): Hardware Revision String (read), Value: bytearray(b'REV 1,0')
2022-12-31 18:04:42,283 __main__ INFO: disconnecting...
2022-12-31 18:04:44,940 __main__ INFO: disconnected
```

Not totally obvious which characteristic(s) will contain sensor data, I am looking for one that has `Unknown (read)` but there doesn't seem to be one like that. I tried reading `b42ebc9e-ade7-11e4-89d3-123b93f75cba` but I get `bleak.exc.BleakDBusError: [org.bluez.Error.NotPermitted] Read not permitted`. Perhaps for this characteristic the device has to be paired? I struggled with that, because even though I could pair with `bluetoothctl`, after connecting to the device there it appears that `bleak` can no longer find it (due to [this](https://github.com/hbldh/bleak/issues/367) ?). Maybe we need to initiate the pairing through `bleak`?

I don't have any experience with BLE yet but will try to play around a bit more. In the mean time, suggestions welcome @ztroop :) 